### PR TITLE
Bump text upper version bounds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ dist/*
 *.diff
 *.o
 *.hi
+.cabal-sandbox/
+cabal.sandbox.config
+cabal.config

--- a/cheapskate.cabal
+++ b/cheapskate.cabal
@@ -44,7 +44,7 @@ library
   build-depends:     base >=4.4 && <4.8,
                      containers >=0.4 && <0.6,
                      mtl >=2.1 && <2.3,
-                     text >= 0.9 && < 1.2,
+                     text >= 0.9 && < 1.3,
                      blaze-html >=0.6 && < 0.8,
                      xss-sanitize >= 0.3 && < 0.4,
                      data-default >= 0.5 && < 0.6,
@@ -61,7 +61,7 @@ executable cheapskate
                      cheapskate,
                      bytestring,
                      blaze-html >=0.6 && < 0.8,
-                     text >= 0.9 && < 1.2
+                     text >= 0.9 && < 1.3
   default-language:  Haskell2010
   ghc-options:       -Wall -fno-warn-unused-do-bind
   ghc-prof-options:  -auto-all -caf-all -rtsopts


### PR DESCRIPTION
Allow `cheapskate` to use `text-1.2.0.0`.
