### PR TITLE
Allow building with base-4.8.0.0

### DIFF
--- a/Cheapskate.hs
+++ b/Cheapskate.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
-
+{-# OPTIONS_GHC -fno-warn-orphans #-}
 module Cheapskate (markdown,
                    def,
                    walk,

--- a/Cheapskate/Html.hs
+++ b/Cheapskate/Html.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE CPP, OverloadedStrings #-}
 module Cheapskate.Html (renderDoc, renderBlocks, renderInlines) where
 import Cheapskate.Types
 import Data.Text (Text)
@@ -8,7 +8,10 @@ import qualified Text.Blaze.Html5.Attributes as A
 import qualified Text.Blaze.Html.Renderer.Text as BT
 import Text.Blaze.Html hiding(contents)
 import Data.Monoid
-import Data.Foldable (foldMap, toList)
+#if !(MIN_VERSION_base(4,8,0))
+import Data.Foldable (foldMap)
+#endif
+import Data.Foldable (toList)
 import qualified Data.Text as T
 import qualified Data.Text.Lazy as TL
 import Data.List (intersperse)

--- a/Cheapskate/Inlines.hs
+++ b/Cheapskate/Inlines.hs
@@ -245,7 +245,7 @@ pUri scheme = do
   guard $ not $ T.null x
   let (rawuri, endingpunct) =
         case T.last x of
-             c | c `elem` ".;?!:," ->
+             c | c `elem` (".;?!:," :: String) ->
                (scheme <> ":" <> T.init x, singleton (Str (T.singleton c)))
              _ -> (scheme <> ":" <> x, mempty)
   return $ autoLink rawuri <> endingpunct

--- a/Cheapskate/Parse.hs
+++ b/Cheapskate/Parse.hs
@@ -460,7 +460,7 @@ leaf lastLineIsText = scanNonindentSpace *> (
    <|> (Rule <$ scanHRuleLine)
    <|> textLineOrBlank
   )
-  where removeATXSuffix t = case T.dropWhileEnd (`elem` " #") t of
+  where removeATXSuffix t = case T.dropWhileEnd (`elem` (" #" :: String)) t of
                                  t' | T.null t' -> t'
                                       -- an escaped \#
                                     | T.last t' == '\\' -> t' <> "#"

--- a/cheapskate.cabal
+++ b/cheapskate.cabal
@@ -41,7 +41,7 @@ library
                      Cheapskate.Inlines
                      Cheapskate.ParserCombinators
                      Paths_cheapskate
-  build-depends:     base >=4.4 && <4.8,
+  build-depends:     base >=4.4 && <4.9,
                      containers >=0.4 && <0.6,
                      mtl >=2.1 && <2.3,
                      text >= 0.9 && < 1.3,
@@ -57,7 +57,7 @@ library
 executable cheapskate
   main-is:           main.hs
   hs-source-dirs:    bin
-  build-depends:     base >=4.4 && <4.8,
+  build-depends:     base >=4.4 && <4.9,
                      cheapskate,
                      bytestring,
                      blaze-html >=0.6 && < 0.8,


### PR DESCRIPTION
Fixes some errors that arise from `Foldable` being moved to `Prelude` (and `elem` being a function of the `Foldable` typeclass) in `base-4.8.0.0`.