### PR TITLE
Add `Generic` and `NFData` instances to Cheapskate types

### DIFF
--- a/Cheapskate/Types.hs
+++ b/Cheapskate/Types.hs
@@ -1,6 +1,9 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 #if !(MIN_VERSION_base(4,4,0))
+-- Both of these extensions are only used when we're deriving
+-- Generic and NFData instances, which we only do if the
+-- GHC version is at least 7.2.
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE StandaloneDeriving #-}
 #endif
@@ -84,6 +87,9 @@ instance Default Options where
 
 
 #if !(MIN_VERSION_base(4,4,0))
+-- The Generic typeclass and the ability to derive it has only
+-- existed since GHC version 7.2, base version 4.4, so we guard
+-- these instance definitions with CPP.
 deriving instance Generic Doc
 instance NFData Doc
 

--- a/Cheapskate/Types.hs
+++ b/Cheapskate/Types.hs
@@ -1,10 +1,20 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveDataTypeable #-}
+#if !(MIN_VERSION_base(4,4,0))
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE StandaloneDeriving #-}
+#endif
 module Cheapskate.Types where
 import Data.Sequence (Seq)
 import Data.Default
 import Data.Text (Text)
 import qualified Data.Map as M
 import Data.Data
+
+#if !(MIN_VERSION_base(4,4,0))
+import Control.DeepSeq (NFData(..))
+import GHC.Generics (Generic)
+#endif
 
 -- | Structured representation of a document.  The 'Options' affect
 -- how the document is rendered by `toHtml`.
@@ -27,6 +37,7 @@ data CodeAttr = CodeAttr { codeLang :: Text, codeInfo :: Text }
               deriving (Show, Data, Typeable)
 
 data ListType = Bullet Char | Numbered NumWrapper Int deriving (Eq,Show,Data,Typeable)
+
 data NumWrapper = PeriodFollowing | ParenFollowing deriving (Eq,Show,Data,Typeable)
 
 -- | Simple representation of HTML tag.
@@ -71,3 +82,29 @@ instance Default Options where
         , debug = False
         }
 
+
+#if !(MIN_VERSION_base(4,4,0))
+deriving instance Generic Doc
+instance NFData Doc
+
+deriving instance Generic Block
+instance NFData Block
+
+deriving instance Generic CodeAttr
+instance NFData CodeAttr
+
+deriving instance Generic ListType
+instance NFData ListType
+
+deriving instance Generic NumWrapper
+instance NFData NumWrapper
+
+deriving instance Generic HtmlTagType
+instance NFData HtmlTagType
+
+deriving instance Generic Inline
+instance NFData Inline
+
+deriving instance Generic Options
+instance NFData Options
+#endif

--- a/cheapskate.cabal
+++ b/cheapskate.cabal
@@ -50,6 +50,8 @@ library
                      data-default >= 0.5 && < 0.7,
                      syb,
                      uniplate >= 1.6 && < 1.7
+  if impl(ghc >= 7.2)
+    build-depends:   deepseq
   default-language:  Haskell2010
   ghc-options:       -Wall -fno-warn-unused-do-bind
 


### PR DESCRIPTION
This is a small PR that adds a few more typeclass instances to the Cheapskate types. Unfortunately, those instances only make sense in GHC version 7.2 or later, so all these instances are guarded by CPP, and the extra dependency needed for `deepseq` is put behind a conditional in the Cabal file as well. This is some extra complexity, but still probably the simplest way of implementing these features while keeping backwards compatibility.

I'd be happy to expand on the motivation for this PR, but the short high-level description is that we're using `cheapskate` in another project—in particular, in the [matterhorn chat client](https://github.com/matterhorn-chat/matterhorn), where we need a Markdown parser that's reasonably fast and produces compact runtime structures—and it turns out that it'd help us to be able to force evaluation of the parsed structure immediately, and this would let us use `deepseq` on that parsed structure.