### PR TITLE
add conditional for cheapskate-dingus deps

### DIFF
--- a/cheapskate.cabal
+++ b/cheapskate.cabal
@@ -1,5 +1,5 @@
 name:                cheapskate
-version:             0.1.0.5
+version:             0.1.0.6
 synopsis:            Experimental markdown processor.
 description:         This is an experimental Markdown processor in pure
                      Haskell.  It aims to process Markdown efficiently and in
@@ -68,8 +68,9 @@ executable cheapskate
 executable cheapskate-dingus
   main-is:           cheapskate-dingus.hs
   hs-source-dirs:    bin
-  build-depends:     base, aeson, cheapskate, blaze-html,
-                     text, wai-extra, wai >= 0.3, http-types
+  if flag(dingus)
+    build-depends:     base, aeson, cheapskate, blaze-html,
+                       text, wai-extra, wai >= 0.3, http-types
   default-language:  Haskell2010
   if flag(dingus)
     Buildable:       True


### PR DESCRIPTION
cheapskate pulls in many unneccesary dependencies when used as a
library with stack or versions of Cabal <1.24 due to including build-deps
of the conditionally buildable cheapskate-dingus stanza.
added an if flag for backwards compatibility to convince stack/Cabal
that we don't need those deps all the time.