### PR TITLE
bump upper version bound on containers library

### DIFF
--- a/cheapskate.cabal
+++ b/cheapskate.cabal
@@ -42,7 +42,7 @@ library
                      Cheapskate.ParserCombinators
                      Paths_cheapskate
   build-depends:     base >=4.4 && <5,
-                     containers >=0.4 && <0.6,
+                     containers >=0.4 && <0.7,
                      mtl >=2.1 && <2.3,
                      text >= 0.9 && < 1.3,
                      blaze-html >=0.6 && < 0.10,


### PR DESCRIPTION
Hi!  Big fan of all your work, thank you for the great libraries :)

Just submitting a small PR to relax the upper version bounds on `containers`, since the 0.6 releases have begun rolloing out.  I've built this on my system to verify that there are no errors on compilation :)  Hope it can be helpful!